### PR TITLE
Improved travis performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 
 script:
   - docker build -t cordi .
-  - docker run cordi /bin/sh -c "cordova create test && cd test && cordova platform add android && cordova build android"
+  - docker run cordi /bin/sh -c "cordova telemetry on && cordova create test && cd test && cordova platform add android && cordova build android"


### PR DESCRIPTION
The `cordova create test` command wait 30 sec for "May Cordova anonymously report usage statistics to improve the tool over time?" question, when we set before the travis finish faster.